### PR TITLE
StyleSheet.create takes an object, not a thunk!

### DIFF
--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -4,6 +4,8 @@ import { defaultSelectorHandlers } from 'aphrodite/lib/generate';
 import cullResponsiveStylesForAmp from './utils/cullResponsiveStylesForAmp';
 import isAmp from './utils/isAmp';
 
+const INLINE_STYLE_KEY = 'inlineStyle';
+
 // Replaces inlines styles with styles that will be converted to
 // class names. We do this because AMP doesn't support inline styles.
 const cssArgNormalizer = (arg, create) => {
@@ -15,7 +17,7 @@ const cssArgNormalizer = (arg, create) => {
   //       this code will have to be updated to match...
   // eslint-disable-next-line no-underscore-dangle
   if (!arg || arg._definition) return arg;
-  return create(() => ({ style: arg })).style;
+  return create({ [INLINE_STYLE_KEY]: arg })[INLINE_STYLE_KEY];
 };
 
 function withAmp(styles, resolve, create) {

--- a/test/ampAphroditeInterfaceFactory_test.js
+++ b/test/ampAphroditeInterfaceFactory_test.js
@@ -3,6 +3,8 @@ import sinon from 'sinon-sandbox';
 import aphrodite from 'aphrodite';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 
+import * as isAmp from '../src/utils/isAmp';
+
 import ampAphroditeInterfaceFactory from '../src/ampAphroditeInterfaceFactory';
 
 describe('ampAphroditeInterfaceFactory', () => {
@@ -96,6 +98,46 @@ describe('ampAphroditeInterfaceFactory', () => {
     it('calls aphroditeInterface.resolveRTL method', () => {
       ampAphroditeInterface.resolveRTL([]);
       expect(aphroditeInterfaceResolveRTLSpy.callCount).to.equal(1);
+    });
+  });
+
+  describe('isAmp set to true', () => {
+    beforeEach(() => {
+      sinon.stub(isAmp, 'default').returns(true);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    describe('.resolve()', () => {
+      it('converts inline styles to classNames', () => {
+        expect(ampAphroditeInterface.resolve([
+          {
+            left: 10,
+          },
+        ])).to.eql({ className: 'inlineStyle_lg4jz7' });
+      });
+    });
+
+    describe('.resolveLTR()', () => {
+      it('converts inline styles to classNames', () => {
+        expect(ampAphroditeInterface.resolveLTR([
+          {
+            left: 10,
+          },
+        ])).to.eql({ className: 'inlineStyle_lg4jz7' });
+      });
+    });
+
+    describe('.resolveRTL()', () => {
+      it('converts inline styles to classNames', () => {
+        expect(ampAphroditeInterface.resolveRTL([
+          {
+            left: 10,
+          },
+        ])).to.eql({ className: 'inlineStyle_6eoou0' });
+      });
     });
   });
 });


### PR DESCRIPTION
This addresses that issue so that inline styles actually get applied as expected in an AMP environment.

to: @airbnb/webinfra 