### PR TITLE
[breaking] Removes non-amp pathways

### DIFF
--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -2,7 +2,6 @@ import { flushToStyleTag, injectAndGetClassName } from 'aphrodite/lib/inject';
 import { defaultSelectorHandlers } from 'aphrodite/lib/generate';
 
 import cullResponsiveStylesForAmp from './utils/cullResponsiveStylesForAmp';
-import isAmp from './utils/isAmp';
 
 const INLINE_STYLE_KEY = 'inlineStyle';
 
@@ -20,18 +19,14 @@ const cssArgNormalizer = (arg, create) => {
   return create({ [INLINE_STYLE_KEY]: arg })[INLINE_STYLE_KEY];
 };
 
-function withAmp(styles, resolve, create) {
-  if (isAmp()) {
-    return {
-      className: injectAndGetClassName(
-        false,
-        styles.map(cullResponsiveStylesForAmp).map(arg => cssArgNormalizer(arg, create)),
-        defaultSelectorHandlers,
-      ),
-    };
-  }
-
-  return resolve(styles);
+function withAmp(styles, create) {
+  return {
+    className: injectAndGetClassName(
+      false,
+      styles.map(cullResponsiveStylesForAmp).map(arg => cssArgNormalizer(arg, create)),
+      defaultSelectorHandlers,
+    ),
+  };
 }
 
 export default aphroditeInterface => ({
@@ -48,18 +43,18 @@ export default aphroditeInterface => ({
   },
 
   resolve(styles) {
-    const { resolve, create } = aphroditeInterface;
-    return withAmp(styles, resolve, create);
+    const { create } = aphroditeInterface;
+    return withAmp(styles, create);
   },
 
   resolveLTR(styles) {
-    const { resolveLTR, createLTR } = aphroditeInterface;
-    return withAmp(styles, resolveLTR, createLTR);
+    const { createLTR } = aphroditeInterface;
+    return withAmp(styles, createLTR);
   },
 
   resolveRTL(styles) {
-    const { resolveRTL, createRTL } = aphroditeInterface;
-    return withAmp(styles, resolveRTL, createRTL);
+    const { createRTL } = aphroditeInterface;
+    return withAmp(styles, createRTL);
   },
 
   // Flushes all buffered styles to a style tag. Required for components

--- a/src/utils/isAmp.js
+++ b/src/utils/isAmp.js
@@ -1,5 +1,0 @@
-// Returns whether the page is an amp page or not. 'process.env.AMP' should be replaced by
-// webpack on compile-time with 'true' or 'false'
-export default function isAmp() {
-  return process.env.AMP;
-}

--- a/test/ampAphroditeInterfaceFactory_test.js
+++ b/test/ampAphroditeInterfaceFactory_test.js
@@ -3,22 +3,14 @@ import sinon from 'sinon-sandbox';
 import aphrodite from 'aphrodite';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 
-import * as isAmp from '../src/utils/isAmp';
-
 import ampAphroditeInterfaceFactory from '../src/ampAphroditeInterfaceFactory';
 
 describe('ampAphroditeInterfaceFactory', () => {
   const { StyleSheetTestUtils } = aphrodite;
   const ampAphroditeInterface = ampAphroditeInterfaceFactory(aphroditeInterface);
-  let aphroditeInterfaceResolveSpy;
-  let aphroditeInterfaceResolveLTRSpy;
-  let aphroditeInterfaceResolveRTLSpy;
 
   beforeEach(() => {
     StyleSheetTestUtils.suppressStyleInjection();
-    aphroditeInterfaceResolveSpy = sinon.spy(aphroditeInterface, 'resolve');
-    aphroditeInterfaceResolveLTRSpy = sinon.spy(aphroditeInterface, 'resolveLTR');
-    aphroditeInterfaceResolveRTLSpy = sinon.spy(aphroditeInterface, 'resolveRTL');
   });
 
   afterEach(() => {
@@ -81,63 +73,32 @@ describe('ampAphroditeInterfaceFactory', () => {
   });
 
   describe('.resolve()', () => {
-    it('calls aphroditeInterface.resolve method', () => {
-      ampAphroditeInterface.resolve([]);
-      expect(aphroditeInterfaceResolveSpy.callCount).to.equal(1);
+    it('converts inline styles to classNames', () => {
+      expect(ampAphroditeInterface.resolve([
+        {
+          left: 10,
+        },
+      ])).to.eql({ className: 'inlineStyle_lg4jz7' });
     });
   });
 
   describe('.resolveLTR()', () => {
-    it('calls aphroditeInterface.resolveLTR method', () => {
-      ampAphroditeInterface.resolveLTR([]);
-      expect(aphroditeInterfaceResolveLTRSpy.callCount).to.equal(1);
+    it('converts inline styles to classNames', () => {
+      expect(ampAphroditeInterface.resolveLTR([
+        {
+          left: 10,
+        },
+      ])).to.eql({ className: 'inlineStyle_lg4jz7' });
     });
   });
 
   describe('.resolveRTL()', () => {
-    it('calls aphroditeInterface.resolveRTL method', () => {
-      ampAphroditeInterface.resolveRTL([]);
-      expect(aphroditeInterfaceResolveRTLSpy.callCount).to.equal(1);
-    });
-  });
-
-  describe('isAmp set to true', () => {
-    beforeEach(() => {
-      sinon.stub(isAmp, 'default').returns(true);
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    describe('.resolve()', () => {
-      it('converts inline styles to classNames', () => {
-        expect(ampAphroditeInterface.resolve([
-          {
-            left: 10,
-          },
-        ])).to.eql({ className: 'inlineStyle_lg4jz7' });
-      });
-    });
-
-    describe('.resolveLTR()', () => {
-      it('converts inline styles to classNames', () => {
-        expect(ampAphroditeInterface.resolveLTR([
-          {
-            left: 10,
-          },
-        ])).to.eql({ className: 'inlineStyle_lg4jz7' });
-      });
-    });
-
-    describe('.resolveRTL()', () => {
-      it('converts inline styles to classNames', () => {
-        expect(ampAphroditeInterface.resolveRTL([
-          {
-            left: 10,
-          },
-        ])).to.eql({ className: 'inlineStyle_6eoou0' });
-      });
+    it('converts inline styles to classNames', () => {
+      expect(ampAphroditeInterface.resolveRTL([
+        {
+          left: 10,
+        },
+      ])).to.eql({ className: 'inlineStyle_6eoou0' });
     });
   });
 });


### PR DESCRIPTION
@gilbox @goatslacker @lencioni 

After debugging a lot of interesting bundling issues related to our amp rendered pages, it has become apparent that referencing an environment variable in a package outside our main application can cause a lot of ??? effects with regards to consistently replacing the value while not duplicating packages by accident in our build process.

It also became apparent that there was no scenario where a bundle may both be amp-rendered and not. We have explicitly different bundles for these scenarios and as such, we could register completely different interfaces. 

The end result is that this package will be specifically targeted at amp rendered pages and will *only* be used with Amp. In all other scenarios, we expect the consumer to use [react-with-styles-interface-aphrodite](https://github.com/airbnb/react-with-styles-interface-aphrodite). 

Note that using this interface *will* break for non-amp pages mostly because match media queries targeting medium and large size screens will be removed entirely. Beyond that, inline styles will be converted to classnames although this should not impact the UI. 

FYI @gabergg @noratarano 