### PR TITLE
Improve tree-shakeability of Aphrodite, drop support for v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/airbnb/react-with-styles-interface-amp-aphrodite#readme",
   "devDependencies": {
     "airbnb-js-shims": "^1.4.0",
-    "aphrodite": "^1.2.5",
+    "aphrodite": "^2.2.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-preset-airbnb": "^2.4.0",
@@ -65,10 +65,10 @@
   },
   "dependencies": {
     "object.assign": "^4.1.0",
-    "react-with-styles-interface-aphrodite": "^4.0.1"
+    "react-with-styles-interface-aphrodite": "^5.0.0"
   },
   "peerDependencies": {
-    "aphrodite": ">=0.5.0",
+    "aphrodite": "^2.2.0",
     "react-with-styles": "^3.0.0"
   }
 }

--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -1,8 +1,26 @@
-import { flushToStyleTag, injectAndGetClassName } from 'aphrodite/lib/inject';
-import { defaultSelectorHandlers } from 'aphrodite/lib/generate';
-
 import cullResponsiveStylesForAmp from './utils/cullResponsiveStylesForAmp';
 import isAmp from './utils/isAmp';
+
+let flushToStyleTag;
+let injectAndGetClassName;
+let defaultSelectorHandlers;
+try {
+  // Aphrodite 1
+  // eslint-disable-next-line import/no-unresolved, global-require
+  ({ flushToStyleTag, injectAndGetClassName } = require('aphrodite/lib/inject'));
+  // eslint-disable-next-line import/no-unresolved, global-require
+  ({ defaultSelectorHandlers } = require('aphrodite/lib/generate'));
+} catch (e) {
+  // Aphrodite 2
+  (
+    {
+      flushToStyleTag,
+      injectAndGetClassName,
+      defaultSelectorHandlers,
+    // eslint-disable-next-line import/no-unresolved, global-require
+    } = require('aphrodite')
+  );
+}
 
 const INLINE_STYLE_KEY = 'inlineStyle';
 

--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -1,26 +1,11 @@
+import {
+  flushToStyleTag,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+} from 'aphrodite';
+
 import cullResponsiveStylesForAmp from './utils/cullResponsiveStylesForAmp';
 import isAmp from './utils/isAmp';
-
-let flushToStyleTag;
-let injectAndGetClassName;
-let defaultSelectorHandlers;
-try {
-  // Aphrodite 1
-  // eslint-disable-next-line import/no-unresolved, global-require
-  ({ flushToStyleTag, injectAndGetClassName } = require('aphrodite/lib/inject'));
-  // eslint-disable-next-line import/no-unresolved, global-require
-  ({ defaultSelectorHandlers } = require('aphrodite/lib/generate'));
-} catch (e) {
-  // Aphrodite 2
-  (
-    {
-      flushToStyleTag,
-      injectAndGetClassName,
-      defaultSelectorHandlers,
-    // eslint-disable-next-line import/no-unresolved, global-require
-    } = require('aphrodite')
-  );
-}
 
 const INLINE_STYLE_KEY = 'inlineStyle';
 

--- a/test/ampAphroditeInterfaceFactory_test.js
+++ b/test/ampAphroditeInterfaceFactory_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
-import aphrodite from 'aphrodite';
+import { StyleSheetTestUtils } from 'aphrodite';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 
 import * as isAmp from '../src/utils/isAmp';
@@ -8,7 +8,6 @@ import * as isAmp from '../src/utils/isAmp';
 import ampAphroditeInterfaceFactory from '../src/ampAphroditeInterfaceFactory';
 
 describe('ampAphroditeInterfaceFactory', () => {
-  const { StyleSheetTestUtils } = aphrodite;
   const ampAphroditeInterface = ampAphroditeInterfaceFactory(aphroditeInterface);
   let aphroditeInterfaceResolveSpy;
   let aphroditeInterfaceResolveLTRSpy;


### PR DESCRIPTION
I originally added support for Aphrodite v2 in a backwards-compatible
way, but had to resort to using CommonJS in a try/catch to make it work.
This will make Aphrodite less tree-shakeable than using the named
export, so I want to get things on that now. This means we have to drop
support for v1, making this a breaking change.

v2 now uses ES modules with named exports, and exposes flushToStyleTag,
injectAndGetClassName, and defaultSelectorHandlers explicitly instead of
requiring a deep import.

More info: https://twitter.com/lencioni/status/974161112110280704

Spiritually similar to:

  https://github.com/airbnb/react-with-styles-interface-aphrodite/pull/43

NOTE this PR is built on top of #5 and should be merged after that one is merged and published.