### PR TITLE
Avoid using two copies of Aphrodite for no-important

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react": "^7.5.1",
     "in-publish": "^2.0.0",
     "mocha": "^4.1.0",
+    "mocha-wrap": "^2.1.2",
     "prop-types": "^15.6.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",

--- a/src/ampAphroditeInterface.js
+++ b/src/ampAphroditeInterface.js
@@ -1,4 +1,15 @@
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
+import {
+  flushToStyleTag,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+} from 'aphrodite';
+
 import ampAphroditeInterfaceFactory from './ampAphroditeInterfaceFactory';
 
-export default ampAphroditeInterfaceFactory(aphroditeInterface);
+export default ampAphroditeInterfaceFactory(
+  aphroditeInterface,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+  flushToStyleTag,
+);

--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -42,56 +42,71 @@ export default (
   injectAndGetClassName,
   defaultSelectorHandlers,
   flushToStyleTag,
-) => ({
-  create(styleHash) {
-    return aphroditeInterface.create(styleHash);
-  },
+) => {
+  // In case someone is calling this function directly without supplying these
+  // aphrodite function arguments, we want to add a fallback behavior to avoid
+  // breaking them.
+  // TODO: Remove this block in next semver-major change
+  if (!injectAndGetClassName || !defaultSelectorHandlers || !flushToStyleTag) {
+    console.warn('You appear to be using ampAphroditeInterfaceFactory in a deprecated a buggy way. Please pass in `injectAndGetClassName`, `defaultSelectorHandlers`, and `flushToStyleTag` as arguments to this function.');
+    ({
+      injectAndGetClassName, // eslint-disable-line no-param-reassign
+      defaultSelectorHandlers, // eslint-disable-line no-param-reassign
+      flushToStyleTag, // eslint-disable-line no-param-reassign
+    } = require('aphrodite')); // eslint-disable-line global-require
+  }
 
-  createLTR(styleHash) {
-    return aphroditeInterface.createLTR(styleHash);
-  },
+  return {
+    create(styleHash) {
+      return aphroditeInterface.create(styleHash);
+    },
 
-  createRTL(styleHash) {
-    return aphroditeInterface.createRTL(styleHash);
-  },
+    createLTR(styleHash) {
+      return aphroditeInterface.createLTR(styleHash);
+    },
 
-  resolve(styles) {
-    const { resolve, create } = aphroditeInterface;
-    return withAmp(
-      styles,
-      resolve,
-      create,
-      injectAndGetClassName,
-      defaultSelectorHandlers,
-    );
-  },
+    createRTL(styleHash) {
+      return aphroditeInterface.createRTL(styleHash);
+    },
 
-  resolveLTR(styles) {
-    const { resolveLTR, createLTR } = aphroditeInterface;
-    return withAmp(
-      styles,
-      resolveLTR,
-      createLTR,
-      injectAndGetClassName,
-      defaultSelectorHandlers,
-    );
-  },
+    resolve(styles) {
+      const { resolve, create } = aphroditeInterface;
+      return withAmp(
+        styles,
+        resolve,
+        create,
+        injectAndGetClassName,
+        defaultSelectorHandlers,
+      );
+    },
 
-  resolveRTL(styles) {
-    const { resolveRTL, createRTL } = aphroditeInterface;
-    return withAmp(
-      styles,
-      resolveRTL,
-      createRTL,
-      injectAndGetClassName,
-      defaultSelectorHandlers,
-    );
-  },
+    resolveLTR(styles) {
+      const { resolveLTR, createLTR } = aphroditeInterface;
+      return withAmp(
+        styles,
+        resolveLTR,
+        createLTR,
+        injectAndGetClassName,
+        defaultSelectorHandlers,
+      );
+    },
 
-  // Flushes all buffered styles to a style tag. Required for components
-  // that depend upon previous styles in the component tree (i.e.
-  // for calculating container width, including padding/margin).
-  flush() {
-    flushToStyleTag();
-  },
-});
+    resolveRTL(styles) {
+      const { resolveRTL, createRTL } = aphroditeInterface;
+      return withAmp(
+        styles,
+        resolveRTL,
+        createRTL,
+        injectAndGetClassName,
+        defaultSelectorHandlers,
+      );
+    },
+
+    // Flushes all buffered styles to a style tag. Required for components
+    // that depend upon previous styles in the component tree (i.e.
+    // for calculating container width, including padding/margin).
+    flush() {
+      flushToStyleTag();
+    },
+  };
+};

--- a/src/ampAphroditeInterfaceFactory.js
+++ b/src/ampAphroditeInterfaceFactory.js
@@ -1,9 +1,3 @@
-import {
-  flushToStyleTag,
-  injectAndGetClassName,
-  defaultSelectorHandlers,
-} from 'aphrodite';
-
 import cullResponsiveStylesForAmp from './utils/cullResponsiveStylesForAmp';
 import isAmp from './utils/isAmp';
 
@@ -23,7 +17,13 @@ const cssArgNormalizer = (arg, create) => {
   return create({ [INLINE_STYLE_KEY]: arg })[INLINE_STYLE_KEY];
 };
 
-function withAmp(styles, resolve, create) {
+function withAmp(
+  styles,
+  resolve,
+  create,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+) {
   if (isAmp()) {
     return {
       className: injectAndGetClassName(
@@ -37,7 +37,12 @@ function withAmp(styles, resolve, create) {
   return resolve(styles);
 }
 
-export default aphroditeInterface => ({
+export default (
+  aphroditeInterface,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+  flushToStyleTag,
+) => ({
   create(styleHash) {
     return aphroditeInterface.create(styleHash);
   },
@@ -52,17 +57,35 @@ export default aphroditeInterface => ({
 
   resolve(styles) {
     const { resolve, create } = aphroditeInterface;
-    return withAmp(styles, resolve, create);
+    return withAmp(
+      styles,
+      resolve,
+      create,
+      injectAndGetClassName,
+      defaultSelectorHandlers,
+    );
   },
 
   resolveLTR(styles) {
     const { resolveLTR, createLTR } = aphroditeInterface;
-    return withAmp(styles, resolveLTR, createLTR);
+    return withAmp(
+      styles,
+      resolveLTR,
+      createLTR,
+      injectAndGetClassName,
+      defaultSelectorHandlers,
+    );
   },
 
   resolveRTL(styles) {
     const { resolveRTL, createRTL } = aphroditeInterface;
-    return withAmp(styles, resolveRTL, createRTL);
+    return withAmp(
+      styles,
+      resolveRTL,
+      createRTL,
+      injectAndGetClassName,
+      defaultSelectorHandlers,
+    );
   },
 
   // Flushes all buffered styles to a style tag. Required for components

--- a/src/no-important.js
+++ b/src/no-important.js
@@ -1,4 +1,15 @@
 import aphroditeInterface from 'react-with-styles-interface-aphrodite/no-important';
+import {
+  flushToStyleTag,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+} from 'aphrodite/no-important';
+
 import ampAphroditeInterfaceFactory from './ampAphroditeInterfaceFactory';
 
-export default ampAphroditeInterfaceFactory(aphroditeInterface);
+export default ampAphroditeInterfaceFactory(
+  aphroditeInterface,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+  flushToStyleTag,
+);

--- a/test/ampAphroditeInterfaceFactory_test.js
+++ b/test/ampAphroditeInterfaceFactory_test.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
-import { StyleSheetTestUtils } from 'aphrodite';
+import {
+  StyleSheetTestUtils,
+  injectAndGetClassName,
+  defaultSelectorHandlers,
+  flushToStyleTag,
+} from 'aphrodite';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 
 import * as isAmp from '../src/utils/isAmp';
@@ -8,7 +13,12 @@ import * as isAmp from '../src/utils/isAmp';
 import ampAphroditeInterfaceFactory from '../src/ampAphroditeInterfaceFactory';
 
 describe('ampAphroditeInterfaceFactory', () => {
-  const ampAphroditeInterface = ampAphroditeInterfaceFactory(aphroditeInterface);
+  const ampAphroditeInterface = ampAphroditeInterfaceFactory(
+    aphroditeInterface,
+    injectAndGetClassName,
+    defaultSelectorHandlers,
+    flushToStyleTag,
+  );
   let aphroditeInterfaceResolveSpy;
   let aphroditeInterfaceResolveLTRSpy;
   let aphroditeInterfaceResolveRTLSpy;


### PR DESCRIPTION
After updating to v2 of this package, we noticed that our AMP builds
started failing with errors like

> Cannot automatically buffer without a document

After some investigation I believe I understand why this happened. The
main difference is that Aphrodite v2 is built using rollup, which means
that the default import and the no-important import are two entirely
separate self-contained modules. And since these modules maintain state,
it is important for them to be the same.

To fix this, I am moving the importing of `aphrodite` or
`aphrodite/no-important` up to the entry point level of this package,
and passing down the useful parts to be consumed by the factory. This
ensures that the same version of Aphrodite is used throughout.

This should have been caught by tests if we hadn't suppressed style
injection, which we don't need to do in this package because of how we
interact with Aphrodite, and if we were using the resolve method and
setting the AMP environment variable. I've addressed all of these issues
in this PR.

While testing this I noticed that when the AMP environment variable is
set, it never uses `!important` even if the non AMP styles use
`!important`. I think this is probably fine due to the constraints of
AMP, but I wasn't entirely sure if it was intentional. I added some
tests to showcase this behavior.

We should follow this up with work in Aphrodite itself that makes this
safer.

---


Add fallback for factory old behavior

In fixing the critical bug that shipped with v2, I needed to change the
API of this function, which makes the bugfix a semver major change. To
make this a semver-minor change, I am adding a fallback here so it still
works as it used to (in a buggy way) if this function is called directly
by some unknown outside consumer.

I think we could potentially detect whether to import from aphrodite or
aphrodite/no-important based on the shape of `aphroditeInterface` here,
but since I don't expect anyone to actually be hitting this codepath, I
didn't bother. The console warning should be enough to help folks
resolve this issue without too much work.